### PR TITLE
fix: set encoding utf8 in https response

### DIFF
--- a/src/httpPromise.js
+++ b/src/httpPromise.js
@@ -4,8 +4,9 @@ module.exports = ((url,urlOptions, data) => {
   return new Promise((resolve, reject) => {
     const req = https.request(url,urlOptions,
       (res) => {
+        res.setEncoding('utf8');
         let body = '';
-        res.on('data', (chunk) => (body += chunk.toString()));
+        res.on('data', (chunk) => (body += chunk));
         res.on('error', reject);
         res.on('end', () => {
           if (res.statusCode >= 200 && res.statusCode <= 299) {


### PR DESCRIPTION
When doing bmc import or bmc pull on bots that have a lot of code actions, they are saved in the workspace with some unrecognized characters. This behavior makes it seem like there are always changes to botmaker's code actions.