### PR TITLE
remove sharp and xml2json deps, fix version reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
 ## How to install botmaker-cli
 - Run `npm i -g @botmaker.org/botmaker-cli`
 
-#### Problems on windows?  
-- Failed `node-gyp` rebuild and/or `python 2.7` issue  
-    - Try running `npm install --global windows-build-tools` on Windows Powershell as Administrator  
-    - Create `PYTHON` environment variable and set `C:\Users\YOUR_USER\.windows-build-tools\python27\python.exe` directory  
-    - Run `bmc` on bash command-line
-    

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botmaker.org/botmaker-cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "botmaker-console",
   "main": "index.js",
   "scripts": {
@@ -38,9 +38,7 @@
     "request": "^2.88.2",
     "request-promise": "^4.2.5",
     "secure-random": "^1.1.1",
-    "xml2js": "^0.6.2",
-    "xml2json": "^0.12.0",
-    "sharp": "^0.32.1"
+    "xml2js": "^0.6.2"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const { version } = require('../package.json');
 const getDiff = require('./getDiff');
 const newCa = require('./newCa');
 const pull = require('./pull');
@@ -88,7 +89,7 @@ const main = async (args) => {
     .demandCommand()
     .help('h')
     .alias('h', 'help')
-    .version("0.1.8")
+    .version(version)
     .epilog('copyright Botmaker 2022')
     .argv;
 


### PR DESCRIPTION
Remove unused sharp and xml2json dependencies (neither referenced in code); xml2json was the last package requiring native compilation via node-gyp, so windows-build-tools are no longer needed — removed that section from README. Wire bmc --version to read from package.json instead of hardcoded string.